### PR TITLE
Improve Offline/Time Lapse/Catch Up Mode

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -303,8 +303,7 @@ function mainLoop() {
 	//Heirloom Shield Swap Check
 	if (shieldEquipped !== game.global.ShieldEquipped.id) HeirloomShieldSwapped();
 
-	//Offline Progress
-	if (!usingRealTimeOffline) setResourceNeeded();
+	setResourceNeeded();
 
 	//AutoMaps
 	autoMap();

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -169,7 +169,7 @@ function delayStart() {
 	game.global.addonUser = true;
 	game.global.autotrimps = true;
 	document.getElementById('activatePortalBtn').setAttribute("onClick", 'activateClicked(); pushSpreadsheetData()');
-	setTimeout(delayStartAgain, 1000);
+	setTimeout(delayStartAgain, 1500);
 }
 
 function swapBaseSettings() {

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -40,6 +40,7 @@ var aTTimeLapseFastLoop = false;
 var originalGameLoop = null;
 var mainLoopInterval = null;
 var guiLoopInterval = null;
+const runInterval = 100;
 
 var autoTrimpSettings = {};
 var MODULES = {};

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -225,7 +225,8 @@ function universeSwapped() {
 }
 
 function mainLoop() {
-
+	//Toggle between timelapse/catchup/offline speed and normal speed.
+	toggleCatchUpMode();
 	//Adjust tooltip when mazWindow is open OR clear our adjustments if it's not.
 	if (mazWindowOpen && !usingRealTimeOffline) {
 		var mazSettings = ["Map Farm", "Map Bonus", "Void Map", "HD Farm", "Raiding", "Bionic Raiding", "Quagmire Farm", "Insanity Farm", "Alchemy Farm", "Hypothermia Farm", "Bone Shrine", "Auto Golden", "Tribute Farm", "Smithy Farm", "Worshipper Farm"];
@@ -460,6 +461,9 @@ function toggleCatchUpMode() {
         mainLoopInterval = setInterval(mainLoop, runInterval);
         guiLoopInterval = setInterval(guiLoop, runInterval * 10);
     }
+
+	if (getPageSetting('disableForTW') && usingRealTimeOffline) return;
+
     //Enable Online Mode after Offline mode was enabled
     if (!usingRealTimeOffline && aTTimeLapseFastLoop) {
         if (mainLoopInterval) clearInterval(mainLoopInterval);

--- a/modules/portal.js
+++ b/modules/portal.js
@@ -67,28 +67,42 @@ function autoPortal(skipDaily) {
 					}
 					return;
 				}
-				zonePostpone += 1;
 				debug("My " + resourceType + "Hr was: " + myHeliumHr + " & the Best " + resourceType + "Hr was: " + bestHeHr + " at zone: " + bestHeHrZone, "portal");
-				cancelTooltip();
-				popupsAT.portal = true;
-				if (popupsAT.remainingTime === Infinity) popupsAT.remainingTime = 5000;
-				tooltip('confirm', null, 'update', '<b>Auto Portaling NOW!</b><p>Hit Delay Portal to WAIT 1 more zone.', 'zonePostpone+=1;; popupsAT.portal = false', '<b>NOTICE: Auto-Portaling in ' + popupsAT.remainingTime + ' seconds....</b>', 'Delay Portal');
-				setTimeout(function () {
-					cancelTooltip()
-					popupsAT.portal = false;
-					popupsAT.remainingTime = Infinity;
-				}, MODULES["portal"].timeout);
-				setTimeout(function () {
-					if (zonePostpone >= 2)
-						return;
-					if (getPageSetting('heliumHourChallenge', universe) !== 'None')
-						challenge = getPageSetting('heliumHourChallenge', universe);
-					else
-						challenge = 0;
+				if (!usingRealTimeOffline) {
+					zonePostpone += 1;
+					cancelTooltip();
+					popupsAT.portal = true;
+					if (popupsAT.remainingTime === Infinity) popupsAT.remainingTime = 5000;
+					tooltip('confirm', null, 'update', '<b>Auto Portaling NOW!</b><p>Hit Delay Portal to WAIT 1 more zone.', 'zonePostpone+=1;; popupsAT.portal = false', '<b>NOTICE: Auto-Portaling in ' + popupsAT.remainingTime + ' seconds....</b>', 'Delay Portal');
+					setTimeout(function () {
+						cancelTooltip()
+						popupsAT.portal = false;
+						popupsAT.remainingTime = Infinity;
+					}, MODULES["portal"].timeout);
+					setTimeout(function () {
+						if (zonePostpone >= 2)
+							return;
+						if (getPageSetting('heliumHourChallenge', universe) !== 'None')
+							challenge = getPageSetting('heliumHourChallenge', universe);
+						else
+							challenge = 0;
 
-					doPortal(challenge, skipDaily);
-					return;
-				}, MODULES["portal"].timeout + 100);
+						doPortal(challenge, skipDaily);
+						return;
+					}, MODULES["portal"].timeout + 100);
+				}
+				else {
+					if (zonePostpone >= 2)
+							return;
+						if (getPageSetting('heliumHourChallenge', universe) !== 'None')
+							challenge = getPageSetting('heliumHourChallenge', universe);
+						else
+							challenge = 0;
+
+						doPortal(challenge, skipDaily);
+						return;
+				}
+
 			}
 			if (game.global.world >= portalZone) {
 				if (getPageSetting('heliumHourChallenge', universe) !== 'None')
@@ -198,30 +212,48 @@ function dailyAutoPortal() {
 					}
 					return;
 				}
-				zonePostpone += 1;
+
 				debug("My " + resourceType + "Hr was: " + myHeliumHr + " & the Best " + resourceType + "Hr was: " + bestHeHr + " at zone: " + bestHeHrZone, "portal");
-				cancelTooltip();
-				popupsAT.portal = true;
-				if (popupsAT.remainingTime === Infinity) popupsAT.remainingTime = 5000;
-				tooltip('confirm', null, 'update', '<b>Auto Portaling NOW!</b><p>Hit Delay Portal to WAIT 1 more zone.', 'zonePostpone+=1; popupsAT.portal = false', '<b>NOTICE: Auto-Portaling in ' + popupsAT.remainingTime + ' seconds....</b>', 'Delay Portal');
-				setTimeout(function () {
-					cancelTooltip()
-					popupsAT.portal = false;
-					popupsAT.remainingTime = Infinity;
-				}, MODULES["portal"].timeout);
-				setTimeout(function () {
+
+				if (!usingRealTimeOffline) {
+					zonePostpone += 1;
+					cancelTooltip();
+					popupsAT.portal = true;
+					if (popupsAT.remainingTime === Infinity) popupsAT.remainingTime = 5000;
+					tooltip('confirm', null, 'update', '<b>Auto Portaling NOW!</b><p>Hit Delay Portal to WAIT 1 more zone.', 'zonePostpone+=1; popupsAT.portal = false', '<b>NOTICE: Auto-Portaling in ' + popupsAT.remainingTime + ' seconds....</b>', 'Delay Portal');
+					setTimeout(function () {
+						cancelTooltip()
+						popupsAT.portal = false;
+						popupsAT.remainingTime = Infinity;
+					}, MODULES["portal"].timeout);
+					setTimeout(function () {
+						if (zonePostpone >= 2)
+							return;
+						if (OKtoPortal) {
+							confirmAbandonChallenge();
+							abandonChallenge();
+							cancelTooltip();
+						}
+						if (getPageSetting('dailyHeliumHourChallenge') !== 'None')
+							doPortal(getPageSetting('dailyHeliumHourChallenge'));
+						else
+							doPortal();
+					}, MODULES["portal"].timeout + 100);
+				}
+				else {
 					if (zonePostpone >= 2)
-						return;
-					if (OKtoPortal) {
-						confirmAbandonChallenge();
-						abandonChallenge();
-						cancelTooltip();
-					}
-					if (getPageSetting('dailyHeliumHourChallenge') !== 'None')
-						doPortal(getPageSetting('dailyHeliumHourChallenge'));
-					else
-						doPortal();
-				}, MODULES["portal"].timeout + 100);
+							return;
+						if (OKtoPortal) {
+							confirmAbandonChallenge();
+							abandonChallenge();
+							cancelTooltip();
+						}
+						if (getPageSetting('dailyHeliumHourChallenge') !== 'None')
+							doPortal(getPageSetting('dailyHeliumHourChallenge'));
+						else
+							doPortal();
+				}
+				
 			}
 		}
 		if (game.global.world >= portalZone) {


### PR DESCRIPTION
I did my time lapse changes to this version
1. Made setResoureces need run in time lapse (no idea what it does but it seems to work even if it also runs in time lapse)
2. Disable Portal warning tooltip when in time lapse mode
3. Slightly Reduce Start up Delay to reduce wasted time lapse time. Not sure if reduced startup delay is 100% stable might have to increase it back to it's orignial value if there are any issues with loading.
4. Increase speed AT runs in timelapse mode by coupling it to the main game loop and running it every 20 gameLoop ticks while in timelapse mode (it automatically swaps between coupled mode in timelapse and running normally outside of time lapse)