### PR TITLE
Run interval code every n AT ticks rather then every n seconds and make sure mainLoop always runs on a new zone

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -283,14 +283,12 @@ function toggleCatchUpMode() {
 			if (loops % getPageSetting('timeWarpFrequency') === 0 || newZone) {
 				mainLoop();
 			}
-			else { 
-				//No need to run per frame action when we are going to run mainLoop anyway.
-				//Running a few functions everytime the game loop runs to ensure we aren't missing out on any mapping that needs to be done.
-				mapSettings = farmingDecision();
-				autoMap();
-				callBetterAutoFight();
-				if (game.global.universe === 2) equalityManagement();
-			}
+
+			//Running a few functions everytime the game loop runs to ensure we aren't missing out on any mapping that needs to be done.
+			mapSettings = farmingDecision();
+			autoMap();
+			callBetterAutoFight();
+			if (game.global.universe === 2) equalityManagement();
 		}
 		debug("TimeLapse Mode Enabled", "offline");
 	}

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -41,6 +41,7 @@ var runInterval = 100;
 var atTimeLapseFastLoop = false;
 var mainLoopInterval = null;
 var guiLoopInterval = null;
+var ATMainLoopCounter = 0;
 
 var autoTrimpSettings = {};
 var MODULES = {};
@@ -319,12 +320,13 @@ function mainLoop() {
 	if (getPageSetting('timeWarpDisable') && usingRealTimeOffline) return;
 	ATrunning = true;
 
+	ATMainLoopCounter++;
 	//Interval code
-	var date = new Date();
-	oneSecondInterval = ((date.getSeconds() % 1) === 0 && (date.getMilliseconds() < 100));
-	twoSecondInterval = ((date.getSeconds() % 2) === 0 && (date.getMilliseconds() < 100));
-	sixSecondInterval = ((date.getSeconds() % 6) === 0 && (date.getMilliseconds() < 100));
-	tenSecondInterval = ((date.getSeconds() % 10) === 0 && (date.getMilliseconds() < 100));
+	//var date = new Date();
+	oneSecondInterval = ATMainLoopCounter % (1000/runInterval) === 0;
+	twoSecondInterval = ATMainLoopCounter % (2000/runInterval) === 0;
+	sixSecondInterval = ATMainLoopCounter % (6000/runInterval) === 0;
+	tenSecondInterval = ATMainLoopCounter % (10000/runInterval) === 0;
 
 	//Offline mode check
 	var shouldRunTW = !usingRealTimeOffline || (usingRealTimeOffline && !getPageSetting('timeWarpSpeed'));

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -278,13 +278,19 @@ function toggleCatchUpMode() {
 		gameLoop = function (makeUp, now) {
 			originalGameLoop(makeUp, now);
 
-			//Running a few functions everytime the game loop runs to ensure we aren't missing out on any mapping that needs to be done.
-			mapSettings = farmingDecision();
-			autoMap();
-			callBetterAutoFight();
-			if (game.global.universe === 2) equalityManagement();
-
-			if (loops % getPageSetting('timeWarpFrequency') === 0) mainLoop();
+			var newZone = lastrunworld !== game.global.world;
+			//Run mainLoop every n game loops and always on a new zone.
+			if (loops % getPageSetting('timeWarpFrequency') === 0 || newZone) {
+				mainLoop();
+			}
+			else { 
+				//No need to run per frame action when we are going to run mainLoop anyway.
+				//Running a few functions everytime the game loop runs to ensure we aren't missing out on any mapping that needs to be done.
+				mapSettings = farmingDecision();
+				autoMap();
+				callBetterAutoFight();
+				if (game.global.universe === 2) equalityManagement();
+			}
 		}
 		debug("TimeLapse Mode Enabled", "offline");
 	}


### PR DESCRIPTION
Intervals run extremally slowly relative to ingame time in timelapse so this makes them run every n mainLoop ticks instead. Also fixes a bug of not correctly calculating H:D in a new zone by making sure the whole main loops runs in new zones.