### PR TITLE
Potential fix for advanced nurseries buying negative nurseries

### DIFF
--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -352,9 +352,10 @@ function buyBuildings() {
 
 			var nurseryPct = buildingSettings.Nursery.percent / 100;
 			var nurseryCanAfford = calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, (nurseryAmt - game.buildings.Nursery.owned), nurseryPct);
+			var nurseryCanAffordNoNurseryLimit = calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, Infinity, nurseryPct);
 			if (nurseryZoneOk || nurseryPreSpire > 0) {
 				if (nurseryPreSpire > 0 && nurseryCanAfford > 0) safeBuyBuilding('Nursery', nurseryCanAfford);
-				else if (advancedNurseries() && calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, 1, nurseryPct) > 0) { safeBuyBuilding('Nursery', Math.min(nurseryCanAfford, getPageSetting('advancedNurseriesAmount'))); }
+				else if (advancedNurseries() && calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, 1, nurseryPct) > 0) { safeBuyBuilding('Nursery', Math.min(nurseryCanAffordNoNurseryLimit, getPageSetting('advancedNurseriesAmount'))); }
 				else if (nurseryCanAfford > 0) safeBuyBuilding('Nursery', nurseryCanAfford);
 			}
 		}

--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -351,7 +351,7 @@ function buyBuildings() {
 			if (nurseryAmt === 0 && !getPageSetting('advancedNurseries')) nurseryAmt = Infinity;
 
 			var nurseryPct = buildingSettings.Nursery.percent / 100;
-			var nurseryCanAfford = calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, (nurseryAmt - game.buildings.Nursery.owned), nurseryPct);
+			var nurseryCanAfford = calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, Math.max(0, (nurseryAmt - game.buildings.Nursery.owned)), nurseryPct);
 			var nurseryCanAffordNoNurseryLimit = calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, Infinity, nurseryPct);
 			if (nurseryZoneOk || nurseryPreSpire > 0) {
 				if (nurseryPreSpire > 0 && nurseryCanAfford > 0) safeBuyBuilding('Nursery', nurseryCanAfford);

--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -355,7 +355,7 @@ function buyBuildings() {
 			var nurseryCanAffordNoNurseryLimit = calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, Infinity, nurseryPct);
 			if (nurseryZoneOk || nurseryPreSpire > 0) {
 				if (nurseryPreSpire > 0 && nurseryCanAfford > 0) safeBuyBuilding('Nursery', nurseryCanAfford);
-				else if (advancedNurseries() && calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, 1, nurseryPct) > 0) { safeBuyBuilding('Nursery', Math.min(nurseryCanAffordNoNurseryLimit, getPageSetting('advancedNurseriesAmount'))); }
+				else if (advancedNurseries() && calculateMaxAffordLocal(game.buildings.Nursery, true, false, false, 1, nurseryPct) > 0) { safeBuyBuilding('Nursery', Math.max(Math.min(nurseryCanAffordNoNurseryLimit, getPageSetting('advancedNurseriesAmount')),1)); }
 				else if (nurseryCanAfford > 0) safeBuyBuilding('Nursery', nurseryCanAfford);
 			}
 		}


### PR DESCRIPTION
This may or may not fix advancded nurseries making nureries bough negative. The problem is that nurseries can afford ends up negative becosue (nurseryAmt - game.buildings.Nursery.owned) and the calc function just returns the negative force max value becosue it's smaller then what you can acutally afford, I added a failsafe to make sure no negative number get's input, also I added a second variable nurseryCanAffordNoNurseryLimit becouse we want the actual max number we can afford for the advanced buying check. I also added another failsafe to the buying process to make sure it really can't buy less then 1 in case the user set amount is negative advanced buy value