### PR TITLE
Distribute fragments among raiding maps

### DIFF
--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3924,7 +3924,7 @@ function prestigeTotalFragCost(getCost) {
 	if (mapSettings.incrementMaps) {
 		for (var i = 1; i < 5; i += 1) {
 			if (prestigesToGet(mapSettings.raidzones - i, mapSettings.prestigeGoal)[0]) {
-				sliders[1] = (prestigeRaidingSliderCost(mapSettings.raidzones - i, mapSettings.special, cost, calcFragmentPercentage(mapSettings.raidzones - i)));
+				sliders[i] = (prestigeRaidingSliderCost(mapSettings.raidzones - i, mapSettings.special, cost, calcFragmentPercentage(mapSettings.raidzones - i)));
 				cost += mapCost(sliders[i][0], sliders[i][1], sliders[i][2], sliders[i][3], sliders[i][4]);
 			}
 			else break;

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -1500,8 +1500,11 @@ function runPrestigeRaiding() {
 	if (!getPageSetting('autoMaps')) return;
 
 	//Initialising prestigeMapArray if it doesn't exist. This is used to store the maps we buy so we can run them later.
-	if (!mapSettings.totalMapCost) mapSettings.totalMapCost = prestigeTotalFragCost(true);
-	if (!mapSettings.mapSliders) mapSettings.mapSliders = prestigeTotalFragCost();
+	if (!mapSettings.totalMapCost || !mapSettings.mapSliders) {
+		var totalMapCost, mapSliders = prestigeTotalFragCost();
+		if (!mapSettings.totalMapCost) mapSettings.totalMapCost = totalMapCost;
+		if (!mapSettings.mapSliders) mapSettings.mapSliders = mapSliders;
+	}
 	if (!mapSettings.prestigeMapArray) mapSettings.prestigeMapArray = new Array(5);
 	if (!mapSettings.prestigeFragMapBought) mapSettings.prestigeFragMapBought = false;
 
@@ -3912,7 +3915,7 @@ function prestigeRaidingSliderCost(raidZone, special, totalCost, fragmentPercent
 }
 
 //Identify total cost of prestige raiding maps
-function prestigeTotalFragCost(getCost) {
+function prestigeTotalFragCost() {
 	var cost = 0;
 	var sliders = new Array(5);
 	var fragmentPercentage = mapSettings.incrementMaps ? calcFragmentPercentage(mapSettings.raidzones) : 1;
@@ -3931,9 +3934,7 @@ function prestigeTotalFragCost(getCost) {
 		}
 	}
 
-	if (getCost)
-		return cost;
-	return sliders;
+    return cost, sliders;
 }
 
 function dailyModiferReduction() {

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -1501,9 +1501,9 @@ function runPrestigeRaiding() {
 
 	//Initialising prestigeMapArray if it doesn't exist. This is used to store the maps we buy so we can run them later.
 	if (!mapSettings.totalMapCost || !mapSettings.mapSliders) {
-		var totalMapCost, mapSliders = prestigeTotalFragCost();
-		if (!mapSettings.totalMapCost) mapSettings.totalMapCost = totalMapCost;
-		if (!mapSettings.mapSliders) mapSettings.mapSliders = mapSliders;
+		var costAndSliders = prestigeTotalFragCost();
+		if (!mapSettings.totalMapCost) mapSettings.totalMapCost = costAndSliders.cost;
+		if (!mapSettings.mapSliders) mapSettings.mapSliders = costAndSliders.sliders;
 	}
 	if (!mapSettings.prestigeMapArray) mapSettings.prestigeMapArray = new Array(5);
 	if (!mapSettings.prestigeFragMapBought) mapSettings.prestigeFragMapBought = false;
@@ -3934,7 +3934,10 @@ function prestigeTotalFragCost() {
 		}
 	}
 
-    return cost, sliders;
+    return {
+		"cost": cost,
+		"sliders": sliders
+	};
 }
 
 function dailyModiferReduction() {


### PR DESCRIPTION
When buying multiple maps for raiding, we will reserve some fragments for later maps rather than use all available fragments for the first map and the rest of the maps are pretty crappy. The reservation follows the following rules:
If this is the last map, use all fragments
If this map is 1 level higher than the next map, use 80% of the fragments
If this map is 6 levels higher than the next map, use 99% of the fragments

Also did some refactors to reduce the number of function calls to prestigesToGet() to improve the performance