### PR TITLE
Fix an edge case that ATGA not removing Geneticists

### DIFF
--- a/modules/breedtimer.js
+++ b/modules/breedtimer.js
@@ -171,7 +171,6 @@ function geneAssist() {
 
 	var now = new Date().getTime();
 	var breedTime = (game.jobs.Amalgamator.owned > 0) ? (now - game.global.lastSoldierSentAt) / 1000 : game.global.lastBreedTime / 1000;
-	var thresh = new MODULES.breedtimer.DecimalBreed(totalTime.mul(0.02));
 	var compareTime;
 	if (timeRemaining.cmp(0.5) > 0) {
 		compareTime = new MODULES.breedtimer.DecimalBreed(timeRemaining.add(breedTime));
@@ -190,7 +189,7 @@ function geneAssist() {
 			addGeneticist(genDif.toNumber());
 		}
 	}
-	else if ((compareTime.add(thresh.mul(-1)).cmp(target) > 0 && timeRemaining.cmp(1) > 0) || (potencyMod().cmp(1) === 0)) {
+	else if ((compareTime.mul(0.98).cmp(target) > 0 && timeRemaining.cmp(1) > 0) || (potencyMod().cmp(1) === 0)) {
 		if (!genDif.isFinite()) genDif = new Decimal(-1);
 		if (genDif.cmp(0) < 0 && game.options.menu.gaFire.enabled !== 2) {
 			if (genDif.cmp(-10) < 0) genDif = new Decimal(-10);


### PR DESCRIPTION
If the total time is way larger than the compare time, it may cause the thresh be larger than the compare time so ATGA removing geneticists does not trigger. This PR changed the thresh to be calculated based on compare time 