### PR TITLE
Improve Desolation destack AL maplevel calculation

### DIFF
--- a/modules/farmCalc.js
+++ b/modules/farmCalc.js
@@ -577,7 +577,7 @@ function lootDefault(zone, saveData)
 
 function lootDestack(zone, saveData)
 {
-	return zone <= saveData.zone ? 0 : zone - saveData.zone;
+	return zone < saveData.zone ? 0 : zone - saveData.zone + 1;
 }
 
 //Return efficiency stats for the given zone

--- a/modules/farmCalc.js
+++ b/modules/farmCalc.js
@@ -587,7 +587,7 @@ function zone_stats(zone, stances = 'X', saveData, lootFunction) {
 		zone: 'z' + zone,
 		value: 0,
 		killSpeed: 0,
-		stance: '',
+		stance: 'X',
 		loot: lootFunction(zone, saveData),
 		canAffordPerfect: saveData.fragments >= mapCost(zone - saveData.zone, saveData.mapSpecial, saveData.mapBiome, [9, 9, 9])
 	};

--- a/modules/farmCalc.js
+++ b/modules/farmCalc.js
@@ -542,7 +542,7 @@ function populateFarmCalcData() {
 }
 
 //Return a list of efficiency stats for all sensible zones
-function stats(lootFunction) {
+function stats(lootFunction = lootDefault) {
 	const saveData = populateFarmCalcData();
 	let stats = [];
 	let extra = 0;


### PR DESCRIPTION
Desolation destack map level choose based on how fast it destacks rather than the fastest map clear