### PR TITLE
Considers Shieldblock Efficiency when buying gyms

### DIFF
--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -1,5 +1,5 @@
 MODULES.buildings = {
-	betaHouseEfficiency: true
+	betaHouseEfficiency: false
 };
 
 function safeBuyBuilding(building, amt) {

--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -1,5 +1,5 @@
 MODULES.buildings = {
-	betaHouseEfficiency: false
+	betaHouseEfficiency: true
 }
 
 function safeBuyBuilding(building, amt) {

--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -329,6 +329,14 @@ function _buyGyms(buildingSettings) {
 	if (!challengeActive('Scientist') && saveWood && (getPageSetting('upgradeType') || game.global.autoUpgrades))
 		return;
 
+	//ShieldBlock cost Effectiveness:
+	if (game.equipment['Shield'].blockNow) {
+		var gymEff = evaluateEquipmentEfficiency('Gym');
+		var shieldEff = evaluateEquipmentEfficiency('Shield');
+		if ((gymEff.wall) || (gymEff.factor <= shieldEff.factor && !gymEff.wall))
+			return;
+	}
+
 	const gymAmt = buildingSettings.Gym.buyMax === 0 ? Infinity : buildingSettings.Gym.buyMax;
 	const purchased = game.buildings.Gym.purchased;
 	const max = gymAmt - purchased;

--- a/modules/buildings.js
+++ b/modules/buildings.js
@@ -1,3 +1,7 @@
+MODULES.buildings = {
+	betaHouseEfficiency: false
+}
+
 function safeBuyBuilding(building, amt) {
 	const queued = isBuildingInQueue(building);
 	const locked = game.buildings[building].locked;
@@ -25,7 +29,7 @@ function advancedNurseries() {
 
 function _housingToCheck() {
 	const housingTypes = ['Hut', 'House', 'Mansion', 'Hotel', 'Resort', 'Gateway', 'Collector'];
-	return housingTypes.filter(_needHousing);
+	return housingTypes.filter(house => _needHousing(house, MODULES.buildings.betaHouseEfficiency));
 }
 
 function _needHousing(houseName, ignoreAffordability) {

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -595,6 +595,12 @@ function getMaxAffordable(baseCost, totalResource, costScaling, isCompounding) {
 	}
 }
 
+function ceilToNearestMultipleOf(number, multipleOf, offSet) {
+	var n = number - offSet;
+	var roundedUp = Math.ceil(n / multipleOf) * multipleOf
+	return roundedUp + offSet
+}
+
 function argSort(array, reverseStability = false) {
 	return array
 		.map((value, index) => [value, index])
@@ -610,7 +616,7 @@ function elementExists(element) {
 }
 
 function elementVisible(element) {
-	visible = document.getElementById(element).style.visibility !== 'hidden';
+	let visible = document.getElementById(element).style.visibility !== 'hidden';
 	return elementExists(element) && visible;
 }
 


### PR DESCRIPTION
Currently uses ressurected old code. Partly adapts the new code to support block efficiency. Currently doesn't consider Gym Efficiency when buying shields.