### PR TITLE
hits survived to push implementation PR2

### DIFF
--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -1493,12 +1493,12 @@ function initialiseAllSettings() {
 		createSetting('hitsSurvivedToPush',
 			function () { return ('Hits Survived To Push') },
 			function () {
-				let description = "<p>Will only be active if 10 map stacks are already obtained. If the next army is ready and currently farming, push the world instead with the current trimps!</p>";
+				let description = "<p>Will only be active at 10 map stacks, no titimps left. If the next army is ready and currently farming, push the world instead with the current trimps!</p>";
 				description += "<p>Set to <b>0 or below</b> to disable this setting.</p>";
 				description += "<p>Your Hits Survived can be seen in either the <b>Auto Maps status tooltip</b> or the AutoTrimp settings <b>Help</b> tab.</p>";
 				description += "<p><b>Recommended:</b> 0.6 for earlygame, gradually increase the further you progress</p>";
 				return description;
-			}, 'value', 0.6, null, "Maps", [1, 2]);
+			}, 'value', 0, null, "Maps", [1, 2]);
 
 		createSetting('mapBonusHealth',
 			function () { return ('Map Bonus Health') },

--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -1489,6 +1489,16 @@ function initialiseAllSettings() {
 				if (currSettingUniverse === 2) description += "<p>Don't set this above 1 when using <b>Auto Equality: Advanced</b> as it can cause you to eternally farm.</p>";
 				return description;
 			}, 'value', 1.25, null, "Maps", [1, 2]);
+		
+		createSetting('hitsSurvivedToPush',
+			function () { return ('Hits Survived To Push') },
+			function () {
+				let description = "<p>Will only be active if 10 map stacks are already obtained. If the next army is ready and currently farming, push the world instead with the current trimps!</p>";
+				description += "<p>Set to <b>0 or below</b> to disable this setting.</p>";
+				description += "<p>Your Hits Survived can be seen in either the <b>Auto Maps status tooltip</b> or the AutoTrimp settings <b>Help</b> tab.</p>";
+				description += "<p><b>Recommended:</b> 0.6 for earlygame, gradually increase the further you progress</p>";
+				return description;
+			}, 'value', 0.6, null, "Maps", [1, 2]);
 
 		createSetting('mapBonusHealth',
 			function () { return ('Map Bonus Health') },

--- a/mods/farmCalcStandalone.js
+++ b/mods/farmCalcStandalone.js
@@ -2,10 +2,10 @@ function getPerkModifier(what) {
 	return game.portal[what].modifier || 0;
 }
 
-function getCurrentEnemy(cell = 1) {
+function getCurrentEnemy(cell = 1, worldCheck = false) {
 	if (game.global.gridArray.length <= 0) return {};
 
-	const mapping = game.global.mapsActive;
+	const mapping = game.global.mapsActive && !worldCheck;
 	const currentCell = mapping ? game.global.lastClearedMapCell + cell : game.global.lastClearedCell + cell;
 	const mapGrid = mapping ? 'mapGridArray' : 'gridArray';
 

--- a/modules/combat.js
+++ b/modules/combat.js
@@ -74,10 +74,10 @@ function _forceAbandonTrimps() {
 }
 
 // Check if we would die from the next enemy attack - Only used in U1
-function _armyDeath() {
+function _armyDeath(worldCheck = false) {
 	if (game.global.universe !== 1 || game.global.mapsActive || game.global.soldierHealth <= 0 || !getPageSetting('avoidEmpower')) return false;
 
-	const enemy = getCurrentEnemy();
+	const enemy = worldCheck ? getCurrentEnemy(0,true):getCurrentEnemy();
 	const fluctuation = game.global.universe === 2 ? 1.5 : 1.2;
 	const runningDaily = challengeActive('Daily');
 	const dailyChallenge = game.global.dailyChallenge;

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3183,6 +3183,7 @@ function _runHDFarm(setting, mapName, settingName, settingIndex, defaultSettings
 		repeat: !repeat,
 		status: status,
 		runCap: mapsRunCap,
+		hitsSurvivedSetting: setting.hitsSurvivedFarm,
 		shouldHealthFarm: hdType.includes('hitsSurvived'),
 		voidHitsSurvived: hdType === 'hitsSurvivedVoid' || hdType === 'void',
 		settingIndex: settingIndex,
@@ -3244,16 +3245,15 @@ function farmingDecision() {
 	//pushes current army after farming, after current army dies, next army starts farming again, repeat
 	//conditions for activating, map bonus = 10, Next Trimps army are ready,hitsSurvivedToPush > 0, hitsSurvived > hitsSurvivedToPush
 	//Takes hdfarm out of the mapcheck pool, disables the currently running map so the trimps advance, once trimps are fighting in world add hdFarm back in the check pool.
-	if(game.global.mapBonus===10 && newArmyRdy() && getPageSetting('hitsSurvivedToPush') > 0 && hdStats['hitsSurvived'] > getPageSetting('hitsSurvivedToPush') && (game.global.mapsActive || !game.global.fighting)){
-		mapSettings.repeat = false;
-		mapSettings.shouldRun = false;
-		const hdFarmIndex = mapTypes.indexOf(hdFarm);
-		if (index !== -1) {
-			mapTypes.splice(hdFarmIndex, 1);
-		}
-	}
-	else{
-		if (game.global.fighting && !game.global.mapsactive){
+	if (!game.global.spireActive && mapSettings.hitsSurvivedSetting) {
+		const hsToPush = getPageSetting('hitsSurvivedToPush');
+		const hsSufficient = hsToPush > 0 && hdStats['hitsSurvived'] > hsToPush;
+		if (hsSufficient && game.global.mapBonus === 10 && (game.global.mapsActive || !game.global.fighting) && newArmyRdy()) {
+			mapSettings.repeat = false;
+			mapSettings.shouldRun = false;
+			const hdFarmIndex = mapTypes.indexOf(hdFarm);
+			if (hdFarmIndex !== -1) mapTypes.splice(hdFarmIndex, 1);
+		} else if (game.global.fighting && !game.global.mapsActive) {
 			mapSettings.repeat = true;
 			mapSettings.shouldRun = true;
 		}

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3249,13 +3249,8 @@ function farmingDecision() {
 		const hsToPush = getPageSetting('hitsSurvivedToPush');
 		const hsSufficient = hsToPush > 0 && hdStats['hitsSurvived'] > hsToPush;
 		if (hsSufficient && game.global.mapBonus === 10 && (game.global.mapsActive || !game.global.fighting) && newArmyRdy()) {
-			mapSettings.repeat = false;
-			mapSettings.shouldRun = false;
 			const hdFarmIndex = mapTypes.indexOf(hdFarm);
 			if (hdFarmIndex !== -1) mapTypes.splice(hdFarmIndex, 1);
-		} else if (game.global.fighting && !game.global.mapsActive) {
-			mapSettings.repeat = true;
-			mapSettings.shouldRun = true;
 		}
 	}
 

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3243,14 +3243,20 @@ function farmingDecision() {
 	if (decaySkipMaps()) mapTypes = [prestigeClimb, voidMaps, _obtainUniqueMap];
 
 	//pushes current army after farming, after current army dies, next army starts farming again, repeat
-	//conditions for activating, map bonus = 10, Next Trimps army are ready,hitsSurvivedToPush > 0, hitsSurvived > hitsSurvivedToPush
+	//conditions for activating, map bonus = 10, Next Trimps army are ready,hitsSurvivedToPush > 0, hitsSurvived > hitsSurvivedToPush, < 2 seconds of titimp
 	//Takes hdfarm out of the mapcheck pool, disables the currently running map so the trimps advance, once trimps are fighting in world add hdFarm back in the check pool.
 	if (!game.global.spireActive) {
 		const hsToPush = getPageSetting('hitsSurvivedToPush');
 		const hsSufficient = hsToPush > 0 && hdStats['hitsSurvived'] > hsToPush;
-		if (hsSufficient && game.global.mapBonus === 10 && (game.global.mapsActive || !game.global.fighting) && newArmyRdy()) {
+		const disableOnChallenges = challengeActive('Trapper') || challengeActive('Trappapalooza');
+		const armyConditions = newArmyRdy() && game.global.titimpLeft < 2 && game.global.mapBonus === 10 && !_armyDeath(true)
+		if (hsSufficient && armyConditions && !disableOnChallenges && (game.global.mapsActive || !game.global.fighting)) {
 			const hdFarmIndex = mapTypes.indexOf(hdFarm);
 			if (hdFarmIndex !== -1) mapTypes.splice(hdFarmIndex, 1);
+			MODULES.maps.farmToPush = true;
+		}
+		else{
+			MODULES.maps.farmToPush = false;
 		}
 	}
 

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3246,6 +3246,7 @@ function farmingDecision() {
 	//Takes hdfarm out of the mapcheck pool, disables the currently running map so the trimps advance, once trimps are fighting in world add hdFarm back in the check pool.
 	if(game.global.mapBonus===10 && newArmyRdy() && getPageSetting('hitsSurvivedToPush') > 0 && hdStats['hitsSurvived'] > getPageSetting('hitsSurvivedToPush') && (game.global.mapsActive || !game.global.fighting)){
 		mapSettings.repeat = false;
+		mapSettings.shouldRun = false;
 		const hdFarmIndex = mapTypes.indexOf(hdFarm);
 		if (index !== -1) {
 			mapTypes.splice(hdFarmIndex, 1);

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3246,9 +3246,10 @@ function farmingDecision() {
 	//Takes hdfarm out of the mapcheck pool, disables the currently running map so the trimps advance, once trimps are fighting in world add hdFarm back in the check pool.
 	if(game.global.mapBonus===10 && newArmyRdy() && getPageSetting('hitsSurvivedToPush') > 0 && hdStats['hitsSurvived'] > getPageSetting('hitsSurvivedToPush') && (game.global.mapsActive || !game.global.fighting)){
 		mapSettings.repeat = false;
-		mapSettings.shouldRun = false;
-		const index = mapTypes.indexOf(hdFarm);
-		const x = mapTypes.splice(index, 1);
+		const hdFarmIndex = mapTypes.indexOf(hdFarm);
+		if (index !== -1) {
+			mapTypes.splice(hdFarmIndex, 1);
+		}
 	}
 	else{
 		if (game.global.fighting && !game.global.mapsactive){

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3241,6 +3241,22 @@ function farmingDecision() {
 	//Skipping map farming if in Decay or Melt and above stack count user input
 	if (decaySkipMaps()) mapTypes = [prestigeClimb, voidMaps, _obtainUniqueMap];
 
+	//pushes current army after farming, after current army dies, next army starts farming again, repeat
+	//conditions for activating, map bonus = 10, Next Trimps army are ready,hitsSurvivedToPush > 0, hitsSurvived > hitsSurvivedToPush
+	//Takes hdfarm out of the mapcheck pool, disables the currently running map so the trimps advance, once trimps are fighting in world add hdFarm back in the check pool.
+	if(game.global.mapBonus===10 && newArmyRdy() && getPageSetting('hitsSurvivedToPush') > 0 && hdStats['hitsSurvived'] > getPageSetting('hitsSurvivedToPush') && (game.global.mapsActive || !game.global.fighting)){
+		mapSettings.repeat = false;
+		mapSettings.shouldRun = false;
+		const index = mapTypes.indexOf(hdFarm);
+		const x = mapTypes.splice(index, 1);
+	}
+	else{
+		if (game.global.fighting && !game.global.mapsactive){
+			mapSettings.repeat = true;
+			mapSettings.shouldRun = true;
+		}
+	}
+
 	const priorityList = [];
 	//If we are currently running a map and it should be continued then continue running it.
 	//Running the entire function again is done to ensure that we update the status message and check if it still wants to run.

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3245,7 +3245,7 @@ function farmingDecision() {
 	//pushes current army after farming, after current army dies, next army starts farming again, repeat
 	//conditions for activating, map bonus = 10, Next Trimps army are ready,hitsSurvivedToPush > 0, hitsSurvived > hitsSurvivedToPush
 	//Takes hdfarm out of the mapcheck pool, disables the currently running map so the trimps advance, once trimps are fighting in world add hdFarm back in the check pool.
-	if (!game.global.spireActive && mapSettings.hitsSurvivedSetting) {
+	if (!game.global.spireActive) {
 		const hsToPush = getPageSetting('hitsSurvivedToPush');
 		const hsSufficient = hsToPush > 0 && hdStats['hitsSurvived'] > hsToPush;
 		if (hsSufficient && game.global.mapBonus === 10 && (game.global.mapsActive || !game.global.fighting) && newArmyRdy()) {

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -194,7 +194,7 @@ function shouldAbandon(zoneCheck = true) {
 
 	//If set to smart abandon then only abandon when
 	//A) Not fighting OR B) army is dead OR C) you have a new army ready to send out and trimps dont want to be push OR D) you can potentially overkill to/past cell 100 (assuming infinity attack)
-	if (setting === 2 && (!game.global.fighting || game.global.soldierHealth <= 0 || (newArmyRdy()&&wantToPush) || (zoneCheck && mapSettings.mapName !== 'Map Bonus' && getCurrentWorldCell().level + Math.max(0, maxOneShotPower(true) - 1) >= 100))) return true;
+	if (setting === 2 && (!game.global.fighting || game.global.soldierHealth <= 0 || (newArmyRdy()&&!wantToPush) || (zoneCheck && mapSettings.mapName !== 'Map Bonus' && getCurrentWorldCell().level + Math.max(0, maxOneShotPower(true) - 1) >= 100))) return true;
 	//If set to always abandon or never abandon and either not fighting or army is dead then abandon and send to maps
 	if (setting === 1 || !game.global.fighting || game.global.soldierHealth <= 0) return true;
 	//Otherwise don't abandon and keep pushing in world

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -185,9 +185,16 @@ function shouldFarmMapCreation(level, special, biome) {
 //Decide whether or not to abandon trimps for mapping
 function shouldAbandon(zoneCheck = true) {
 	const setting = getPageSetting('autoAbandon');
+	
+	const hsSetting= getPageSetting('hitsSurvived');
+	const hsToPush = getPageSetting('hitsSurvivedToPush');
+	const hitsSurvived = hdStats['hitsSurvived'];
+	const hsBound = hsToPush > 0 && hitsSurvived > hsToPush && hitsSurvived < hsSetting;
+	const wantToPush = hsBound && game.global.mapBonus === 10;
+
 	//If set to smart abandon then only abandon when
-	//A) Not fighting OR B) army is dead OR C) you have a new army ready to send out OR D) you can potentially overkill to/past cell 100 (assuming infinity attack)
-	if (setting === 2 && (!game.global.fighting || game.global.soldierHealth <= 0 || newArmyRdy() || (zoneCheck && mapSettings.mapName !== 'Map Bonus' && getCurrentWorldCell().level + Math.max(0, maxOneShotPower(true) - 1) >= 100))) return true;
+	//A) Not fighting OR B) army is dead OR C) you have a new army ready to send out and trimps dont want to be push OR D) you can potentially overkill to/past cell 100 (assuming infinity attack)
+	if (setting === 2 && (!game.global.fighting || game.global.soldierHealth <= 0 || (newArmyRdy()&&wantToPush) || (zoneCheck && mapSettings.mapName !== 'Map Bonus' && getCurrentWorldCell().level + Math.max(0, maxOneShotPower(true) - 1) >= 100))) return true;
 	//If set to always abandon or never abandon and either not fighting or army is dead then abandon and send to maps
 	if (setting === 1 || !game.global.fighting || game.global.soldierHealth <= 0) return true;
 	//Otherwise don't abandon and keep pushing in world

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -8,7 +8,8 @@ MODULES.maps = {
 	mapRepeatsSmithy: [0, 0, 0],
 	mapTimer: 0,
 	lastMapWeWereIn: null,
-	fragmentCost: Infinity
+	fragmentCost: Infinity,
+	farmToPush: false
 };
 
 function autoMapsStatus(get) {
@@ -185,13 +186,7 @@ function shouldFarmMapCreation(level, special, biome) {
 //Decide whether or not to abandon trimps for mapping
 function shouldAbandon(zoneCheck = true) {
 	const setting = getPageSetting('autoAbandon');
-	
-	const hsSetting= getPageSetting('hitsSurvived');
-	const hsToPush = getPageSetting('hitsSurvivedToPush');
-	const hitsSurvived = hdStats['hitsSurvived'];
-	const hsBound = hsToPush > 0 && hitsSurvived > hsToPush && hitsSurvived < hsSetting;
-	const wantToPush = hsBound && game.global.mapBonus === 10;
-
+	const wantToPush = MODULES.map.farmToPush;
 	//If set to smart abandon then only abandon when
 	//A) Not fighting OR B) army is dead OR C) you have a new army ready to send out and trimps dont want to be push OR D) you can potentially overkill to/past cell 100 (assuming infinity attack)
 	if (setting === 2 && (!game.global.fighting || game.global.soldierHealth <= 0 || (newArmyRdy()&&!wantToPush) || (zoneCheck && mapSettings.mapName !== 'Map Bonus' && getCurrentWorldCell().level + Math.max(0, maxOneShotPower(true) - 1) >= 100))) return true;

--- a/modules/stance.js
+++ b/modules/stance.js
@@ -199,6 +199,15 @@ function wouldSurvive(formation = 'S', critPower = 2, ignoreArmy) {
 	let minDamage = MODULES.stats.baseMinDamage;
 	let maxDamage = MODULES.stats.baseMaxDamage;
 	const newSquadRdy = !ignoreArmy && newArmyRdy();
+	
+	//In support of hitsSurvivedToPush function, to push after farm while a new army is ready
+	//If hitsurvived is less than the hitsSurvived setting, but greater than hitsSurvivedToPush, along with 10 map bonus 
+	//The assumption is that the current trimp army wants to be pushing rather than waiting for the current trimps to die
+	const hsSetting= getPageSetting('hitsSurvived');
+	const hsToPush = getPageSetting('hitsSurvivedToPush');
+	const hitsSurvived = hdStats['hitsSurvived'];
+	const hsBound = hsToPush > 0 && hitsSurvived > hsToPush && hitsSurvived < hsSetting;
+	const wantToPush = hsBound && game.global.mapBonus === 10;
 
 	// Applies the formation modifiers
 	if (formation === 'XB') {
@@ -246,8 +255,8 @@ function wouldSurvive(formation = 'S', critPower = 2, ignoreArmy) {
 	const healthier = health * Math.pow(1.01, game.jobs.Geneticist.owned - game.global.lastLowGen);
 	const maxHealthier = maxHealth * Math.pow(1.01, game.jobs.Geneticist.owned - game.global.lastLowGen);
 	const harm2 = _directDamage(blockier, pierce, healthier, minDamage, critPower) + _challengeDamage(maxHealthier, minDamage, maxDamage, 0, blockier, pierce, critPower);
-
-	return (newSquadRdy && notSpire && healthier > harm2) || health - missingHealth > harm;
+	
+	return (!wantToPush && newSquadRdy && notSpire && healthier > harm2) || health - missingHealth > harm;
 }
 
 function checkStanceSetting() {

--- a/modules/stance.js
+++ b/modules/stance.js
@@ -199,15 +199,6 @@ function wouldSurvive(formation = 'S', critPower = 2, ignoreArmy) {
 	let minDamage = MODULES.stats.baseMinDamage;
 	let maxDamage = MODULES.stats.baseMaxDamage;
 	const newSquadRdy = !ignoreArmy && newArmyRdy();
-	
-	//In support of hitsSurvivedToPush function, to push after farm while a new army is ready
-	//If hitsurvived is less than the hitsSurvived setting, but greater than hitsSurvivedToPush, along with 10 map bonus 
-	//The assumption is that the current trimp army wants to be pushing rather than waiting for the current trimps to die
-	const hsSetting= getPageSetting('hitsSurvived');
-	const hsToPush = getPageSetting('hitsSurvivedToPush');
-	const hitsSurvived = hdStats['hitsSurvived'];
-	const hsBound = hsToPush > 0 && hitsSurvived > hsToPush && hitsSurvived < hsSetting;
-	const wantToPush = hsBound && game.global.mapBonus === 10;
 
 	// Applies the formation modifiers
 	if (formation === 'XB') {
@@ -255,6 +246,10 @@ function wouldSurvive(formation = 'S', critPower = 2, ignoreArmy) {
 	const healthier = health * Math.pow(1.01, game.jobs.Geneticist.owned - game.global.lastLowGen);
 	const maxHealthier = maxHealth * Math.pow(1.01, game.jobs.Geneticist.owned - game.global.lastLowGen);
 	const harm2 = _directDamage(blockier, pierce, healthier, minDamage, critPower) + _challengeDamage(maxHealthier, minDamage, maxDamage, 0, blockier, pierce, critPower);
+	
+	
+	//In support of hitsSurvivedToPush function, to push after farm while a new army is ready
+	wantToPush = MODULES.maps.farmToPush
 	
 	return (!wantToPush && newSquadRdy && notSpire && healthier > harm2) || health - missingHealth > harm;
 }


### PR DESCRIPTION
3/18 Added autostance support to pushing with an army up when pushing conditions are true
3/19 Added a condition to Smart Abandon, to properly support how hits survived to push implementation is working
3/19 Removed the editing of map conditions when removing hdfarm out of the check pool

 There might be a little clear difference. need to check with time warp
Testing it around z85, z99 it is hard to say much of a difference because lots of things like jestimp can affect it. The pushing needs more support. Its a bit more resources?

for later world conditions like with corrupted cells its sufficient to check the world cell the army is at?