### PR TITLE
hitsSurvivedToPush implementation PR3

### DIFF
--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -1501,6 +1501,16 @@ function initialiseAllSettings() {
 				if (currSettingUniverse === 2) description += "<p>Don't set this above 1 when using <b>Auto Equality: Advanced</b> as it can cause you to eternally farm.</p>";
 				return description;
 			}, 'value', 1.25, null, "Maps", [1, 2]);
+		
+		createSetting('hitsSurvivedToPush',
+			function () { return ('Hits Survived To Push') },
+			function () {
+				let description = "<p>Will only be active at 10 map stacks, no titimps left. If the next army is ready and currently farming, push the world instead with the current trimps!</p>";
+				description += "<p>Set to <b>0 or below</b> to disable this setting.</p>";
+				description += "<p>Your Hits Survived can be seen in either the <b>Auto Maps status tooltip</b> or the AutoTrimp settings <b>Help</b> tab.</p>";
+				description += "<p><b>Recommended:</b> 0.6 for earlygame, gradually increase the further you progress</p>";
+				return description;
+			}, 'value', 0, null, "Maps", [1, 2]);
 
 		createSetting('mapBonusHealth',
 			function () { return ('Map Bonus Health') },

--- a/mods/farmCalcStandalone.js
+++ b/mods/farmCalcStandalone.js
@@ -2,10 +2,10 @@ function getPerkModifier(what) {
 	return game.portal[what].modifier || 0;
 }
 
-function getCurrentEnemy(cell = 1) {
+function getCurrentEnemy(cell = 1, worldCheck = false) {
 	if (game.global.gridArray.length <= 0) return {};
 
-	const mapping = game.global.mapsActive;
+	const mapping = game.global.mapsActive && !worldCheck;
 	const currentCell = mapping ? game.global.lastClearedMapCell + cell : game.global.lastClearedCell + cell;
 	const mapGrid = mapping ? 'mapGridArray' : 'gridArray';
 

--- a/mods/farmCalcStandalone.js
+++ b/mods/farmCalcStandalone.js
@@ -2,10 +2,10 @@ function getPerkModifier(what) {
 	return game.portal[what].modifier || 0;
 }
 
-function getCurrentEnemy(cell = 1, worldCheck = false) {
+function getCurrentEnemy(cell = 1) {
 	if (game.global.gridArray.length <= 0) return {};
 
-	const mapping = game.global.mapsActive && !worldCheck;
+	const mapping = game.global.mapsActive;
 	const currentCell = mapping ? game.global.lastClearedMapCell + cell : game.global.lastClearedCell + cell;
 	const mapGrid = mapping ? 'mapGridArray' : 'gridArray';
 

--- a/modules/combat.js
+++ b/modules/combat.js
@@ -75,9 +75,9 @@ function _forceAbandonTrimps() {
 
 // Check if we would die from the next enemy attack - Only used in U1
 function _armyDeath(worldCheck = false) {
-	if (game.global.universe !== 1 || game.global.mapsActive || game.global.soldierHealth <= 0 || !getPageSetting('avoidEmpower')) return false;
+	if (game.global.universe !== 1 || (game.global.mapsActive && !worldCheck) || game.global.soldierHealth <= 0 || !getPageSetting('avoidEmpower')) return false;
 
-	const enemy = worldCheck ? getCurrentEnemy(0,true):getCurrentEnemy();
+	const enemy = worldCheck ? getCurrentEnemy(1, true):getCurrentEnemy();
 	const fluctuation = game.global.universe === 2 ? 1.5 : 1.2;
 	const runningDaily = challengeActive('Daily');
 	const dailyChallenge = game.global.dailyChallenge;

--- a/modules/combat.js
+++ b/modules/combat.js
@@ -74,10 +74,10 @@ function _forceAbandonTrimps() {
 }
 
 // Check if we would die from the next enemy attack - Only used in U1
-function _armyDeath() {
+function _armyDeath(worldCheck = false) {
 	if (game.global.universe !== 1 || game.global.mapsActive || game.global.soldierHealth <= 0 || !getPageSetting('avoidEmpower')) return false;
 
-	const enemy = getCurrentEnemy();
+	const enemy = worldCheck ? getCurrentEnemy(0,true):getCurrentEnemy();
 	const fluctuation = game.global.universe === 2 ? 1.5 : 1.2;
 	const runningDaily = challengeActive('Daily');
 	const dailyChallenge = game.global.dailyChallenge;

--- a/modules/mapFunctions.js
+++ b/modules/mapFunctions.js
@@ -3193,6 +3193,7 @@ function _runHDFarm(setting, mapName, settingName, settingIndex, defaultSettings
 		repeat: !repeat,
 		status: status,
 		runCap: mapsRunCap,
+		hitsSurvivedSetting: setting.hitsSurvivedFarm,
 		shouldHealthFarm: hdType.includes('hitsSurvived'),
 		voidHitsSurvived: hdType === 'hitsSurvivedVoid' || hdType === 'void',
 		settingIndex: settingIndex,
@@ -3250,6 +3251,28 @@ function farmingDecision() {
 
 	//Skipping map farming if in Decay or Melt and above stack count user input
 	if (decaySkipMaps()) mapTypes = [prestigeClimb, voidMaps, _obtainUniqueMap];
+
+	//pushes current army after farming, after current army dies, next army starts farming again, repeat
+	//conditions for activating, map bonus = 10, Next Trimps army are ready,hitsSurvivedToPush > 0, hitsSurvived > hitsSurvivedToPush, < 2 seconds of titimp
+	//Takes hdfarm out of the mapcheck pool, disables the currently running map so the trimps advance, once trimps are fighting in world add hdFarm back in the check pool.
+	if (!game.global.spireActive) {
+		const hsToPush = getPageSetting('hitsSurvivedToPush');
+		const hsSufficient = hsToPush > 0 && hdStats['hitsSurvived'] > hsToPush;
+		const disableOnChallenges = challengeActive('Trapper') || challengeActive('Trappapalooza');
+		const armyConditions = newArmyRdy() && game.global.titimpLeft < 2 && game.global.mapBonus === 10 & !_armyDeath(true) ;
+		
+		//debug(`Running army conditions ${armyConditions} disableOnChallenges ${disableOnChallenges} hsSufficient ${armyConditions} `, 'maps');
+		if (hsSufficient && armyConditions && !disableOnChallenges) {
+			if (game.global.mapsActive || !game.global.fighting){
+				const hdFarmIndex = mapTypes.indexOf(hdFarm);
+				if (hdFarmIndex !== -1) mapTypes.splice(hdFarmIndex, 1);
+				MODULES.maps.farmToPush = true;
+			}
+		}
+		else {
+			MODULES.maps.farmToPush = false;
+		}
+	}
 
 	const priorityList = [];
 	//If we are currently running a map and it should be continued then continue running it.

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -8,7 +8,8 @@ MODULES.maps = {
 	mapRepeatsSmithy: [0, 0, 0],
 	mapTimer: 0,
 	lastMapWeWereIn: null,
-	fragmentCost: Infinity
+	fragmentCost: Infinity,
+	farmToPush: false
 };
 
 function autoMapsStatus(get) {
@@ -185,9 +186,11 @@ function shouldFarmMapCreation(level, special, biome) {
 //Decide whether or not to abandon trimps for mapping
 function shouldAbandon(zoneCheck = true) {
 	const setting = getPageSetting('autoAbandon');
+	const wantToPush = MODULES.maps.farmToPush;
+	
 	//If set to smart abandon then only abandon when
-	//A) Not fighting OR B) army is dead OR C) you have a new army ready to send out OR D) you can potentially overkill to/past cell 100 (assuming infinity attack)
-	if (setting === 2 && (!game.global.fighting || game.global.soldierHealth <= 0 || newArmyRdy() || (zoneCheck && mapSettings.mapName !== 'Map Bonus' && getCurrentWorldCell().level + Math.max(0, maxOneShotPower(true) - 1) >= 100))) return true;
+	//A) Not fighting OR B) army is dead OR C) you have a new army ready to send out and trimps dont want to be push OR D) you can potentially overkill to/past cell 100 (assuming infinity attack)
+	if (setting === 2 && ((!game.global.fighting && !wantToPush) || game.global.soldierHealth <= 0 || (newArmyRdy() && !wantToPush) || (zoneCheck && mapSettings.mapName !== 'Map Bonus' && getCurrentWorldCell().level + Math.max(0, maxOneShotPower(true) - 1) >= 100))) return true;
 	//If set to always abandon or never abandon and either not fighting or army is dead then abandon and send to maps
 	if (setting === 1 || !game.global.fighting || game.global.soldierHealth <= 0) return true;
 	//Otherwise don't abandon and keep pushing in world

--- a/modules/query.js
+++ b/modules/query.js
@@ -211,10 +211,10 @@ function canU2OverkillAT(targetZone = game.global.world) {
 	return targetZone <= hze * allowed;
 }
 
-function getCurrentEnemy(cell = 1) {
+function getCurrentEnemy(cell = 1, worldCheck = false) {
 	if (game.global.gridArray.length <= 0) return {};
 
-	const mapping = game.global.mapsActive;
+	const mapping = game.global.mapsActive && !worldCheck;
 	const currentCell = mapping ? game.global.lastClearedMapCell + cell : game.global.lastClearedCell + cell;
 	const mapGrid = mapping ? 'mapGridArray' : 'gridArray';
 

--- a/modules/stance.js
+++ b/modules/stance.js
@@ -212,8 +212,12 @@ function wouldSurvive(formation = 'S', critPower = 2, baseStats = getBaseStats()
 	const healthier = health * Math.pow(1.01, game.jobs.Geneticist.owned - game.global.lastLowGen);
 	const maxHealthier = maxHealth * Math.pow(1.01, game.jobs.Geneticist.owned - game.global.lastLowGen);
 	const harm2 = _directDamage(blockier, pierce, healthier, minDamage, critPower) + _challengeDamage(maxHealthier, minDamage, maxDamage, 0, blockier, pierce, critPower);
-
-	return newSquadRdy && notSpire && healthier > harm2;
+	
+	
+	//In support of hitsSurvivedToPush function, to push after farm while a new army is ready
+	wantToPush = MODULES.maps.farmToPush;
+	
+	return !wantToPush && newSquadRdy && notSpire && healthier > harm2;
 }
 
 function unlockedStances() {


### PR DESCRIPTION
Default, set at 0 and disabled - People will have to place a value to try it out
will not be used in Trapper, Trappapalooza challenges
Checks world enemy if one shot
must have at least 10 bonus map repeats
titimps < 2 seconds left

uses MODULES.maps.farmToPush to hold the calculation for whether to be pushing in this manner for Stance switching, and smartabandon support

Differences in grey isn't visible because forgoing health for full blocking is not supported right now in AT. Wood farming is also not supported for block. A longer Timewarp may show more subtle differences, but with how farmtopush works, it requires 1 tick timewarps mostly because of timing. Maybe the first time push to z35 might show some differences? It will just be a bit of time to test properly

On a save at z99 with 167k he I compared with and without, using a 10 hour timewarp. same at settings
Without farmToPush - pushed to the start of z105 and farmed there for a while, last prestige is a 21 dagger
with farmToPush - Pushed to the last boss at the end of z106 cell 100 and last prestige is a 21 boot. A longer timewarp may show a little more difference? 

https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcHk0NHo4bGdoM280czl0ZGlqMTRnaWVqaG1jcTQ1a3RqZGt1eHNmaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/w25PEUZWLbE4RDaxfO/giphy.gif

start
[Trimps Save P26 Z99(4).txt](https://github.com/SadAugust/AutoTrimps/files/14669432/Trimps.Save.P26.Z99.4.txt)
without
[Trimps Save P26 Z105(2).txt](https://github.com/SadAugust/AutoTrimps/files/14669274/Trimps.Save.P26.Z105.2.txt)
with
[Trimps Save P26 Z106.txt](https://github.com/SadAugust/AutoTrimps/files/14669275/Trimps.Save.P26.Z106.txt)
AT settings
[AT Settings P26 Z99(3).txt](https://github.com/SadAugust/AutoTrimps/files/14669501/AT.Settings.P26.Z99.3.txt)


This is live on my github page https://github.com/kawyua/AutoTrimps/tree/page-deployment