### PR TITLE
initial defense heirloom switch test PR1

### DIFF
--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -3139,6 +3139,16 @@ function initialiseAllSettings() {
 			}, 'textValue', 'undefined', null, 'Heirloom', [1, 2],
 			function () { return (getPageSetting('heirloom', currSettingUniverse) && getPageSetting('heirloomShield', currSettingUniverse)) });
 
+			
+			createSetting('heirloomDefense',
+			function () { return ('Defense') },
+			function () {
+				let description = "<p>Shield to use when your army loads in. Block, Trainer Efficiency mods from heirlooms stays persistent on an army</p>";
+				description += "<p>Set to <b>undefined</b> to disable.</p>";
+				return description;
+			}, 'textValue', 'undefined', null, 'Heirloom', [1, 2],
+			function () { return (getPageSetting('heirloom', currSettingUniverse) && getPageSetting('heirloomShield', currSettingUniverse)) });
+
 		createSetting('heirloomVoid',
 			function () { return ('Void') },
 			function () {

--- a/modules/heirlooms.js
+++ b/modules/heirlooms.js
@@ -186,6 +186,11 @@ function heirloomShieldToEquip(mapType, swapLooms = false, hdCheck = true, sendi
 		if (getPageSetting('heirloomBreed') !== 'undefined') return 'heirloomBreed';
 	}
 
+	if (swapLooms && !game.global.fighting && !sendingArmy && newArmyRdy()) {
+		console.log('heirloom swapping defense', 'other');
+		if (getPageSetting('heirloomDefense') !== 'undefined') return 'heirloomDefense';
+	}
+
 	const currChallenge = game.global.challengeActive.toLowerCase();
 
 	//Identify the swap zone for shield swapping.
@@ -216,10 +221,8 @@ function heirloomShieldToEquip(mapType, swapLooms = false, hdCheck = true, sendi
 	//Challenges where abandoning your current army has the potential to be REALLY bad.
 	const dontSwap = currChallenge === 'trapper' || (currChallenge === 'berserk' && game.challenges.Berserk.weakened !== 20) || currChallenge === 'trappapalooza';
 	if (swapLooms) {
-		//Disable Shield swapping if on a dontSwap challenge and our army is still fighting or has health remaining.
-		if (dontSwap && (game.global.fighting || game.global.soldierHealthRemaining > 0)) return;
-		//Disable shield swapping depending on auto abandon setting
-		if (!shouldAbandon(false)) return;
+		//Disable Shield swapping if on a dontSwap challenge
+		if (dontSwap) return;
 		//Disable plagueSwap variable if we are querying a map
 		if (mapType === 'map' && swapLooms) MODULES.heirlooms.plagueSwap = false;
 	}

--- a/modules/heirlooms.js
+++ b/modules/heirlooms.js
@@ -187,7 +187,6 @@ function heirloomShieldToEquip(mapType, swapLooms = false, hdCheck = true, sendi
 	}
 
 	if (swapLooms && !game.global.fighting && !sendingArmy && newArmyRdy()) {
-		console.log('heirloom swapping defense', 'other');
 		if (getPageSetting('heirloomDefense') !== 'undefined') return 'heirloomDefense';
 	}
 

--- a/modules/heirlooms.js
+++ b/modules/heirlooms.js
@@ -186,7 +186,7 @@ function heirloomShieldToEquip(mapType, swapLooms = false, hdCheck = true, sendi
 		if (getPageSetting('heirloomBreed') !== 'undefined') return 'heirloomBreed';
 	}
 
-	if (swapLooms && !game.global.fighting && !sendingArmy && newArmyRdy()) {
+	if (swapLooms && !game.global.fighting && !sendingArmy && newArmyRdy() && game.global.universe === 1) {
 		if (getPageSetting('heirloomDefense') !== 'undefined') return 'heirloomDefense';
 	}
 

--- a/modules/modifyGameFunctions.js
+++ b/modules/modifyGameFunctions.js
@@ -67,7 +67,7 @@ game.options.menu.pauseGame.onToggle = function () {
 
 originalstartFight = startFight;
 startFight = function () {
-	if (!game.global.fighting && MODULES.heirlooms.breedHeirloom) {
+	if (!game.global.fighting && (MODULES.heirlooms.breedHeirloom || MODULES.heirlooms.breedDefense)) {
 		heirloomSwapping(true);
 	}
 	originalstartFight(...arguments);

--- a/modules/modifyGameFunctions.js
+++ b/modules/modifyGameFunctions.js
@@ -749,7 +749,6 @@ function calculateMaxAfford_AT(itemObj, isBuilding, isEquipment, isJob, forceMax
 		}
 		if (mostAfford === -1 || mostAfford > toBuy) mostAfford = toBuy;
 	}
-
 	if (forceRatio && (mostAfford <= 0 || isNaN(mostAfford))) return 0;
 	if (isBuilding && mostAfford > 1000000000) return 1000000000;
 	if (mostAfford <= 0) return 1;


### PR DESCRIPTION
In order for the defense heirloom switch to work I had to take out some conditionals that prevented heirloom swaps while the trimps are in combat. I'm not sure why these conditions are necessary, maybe to reduce function calls?

Goal: If a player defines a heirloomDefense setting and is in universe 1, on deployment of trimps use the block/trainer shield, then after deployment switch back to the afterpush shield. Maybe a work in progress if more optimizing/conditions to be wary of appears.

Closed: its a bug in the game. will only include in my version

gif of it working
https://imgur.com/a/djcfznm

used for test:
[AT Settings P26 Z102.txt](https://github.com/SadAugust/AutoTrimps/files/14722400/AT.Settings.P26.Z102.txt)
[Trimps Save P26 Z102.txt](https://github.com/SadAugust/AutoTrimps/files/14722401/Trimps.Save.P26.Z102.txt)


