### PR TITLE
Cut farmcalc simulations off early if we can't afford it or if we have passed the inflection point

### DIFF
--- a/mods/farmCalc.js
+++ b/mods/farmCalc.js
@@ -431,11 +431,11 @@ function stats(lootFunction = lootDefault) {
 	let mapsCanAffordPerfect = 0;
 	let coords = 1;
 	const runningAutoTrimps = typeof atSettings !== 'undefined';
-	let onlyAllowPerfect = runningAutoTrimps && getPageSetting('onlyPerfectMaps');
-	let requiredNumberOfPerfectMaps = onlyAllowPerfect ? 6 : 1;
-	let deltaBetweenCurrentRunAndPriorRunToStopAt = 0.95;
-	let minMapsBelowCurrentZoneToRunFor = 0;
-	let maxMapsToCalcFor = 25;
+	const onlyAllowPerfect = runningAutoTrimps && getPageSetting('onlyPerfectMaps');
+	const requiredNumberOfPerfectMaps = onlyAllowPerfect ? 6 : 1;
+	const deltaBetweenCurrentRunAndPriorRunToStopAt = 0.95;
+	const minMapsBelowCurrentZoneToRunFor = 0;
+	const maxMapsToCalcFor = 25;
 
 	if (saveData.coordinate) {
 		for (let z = 1; z < saveData.zone + extra + 1; ++z) {
@@ -455,10 +455,10 @@ function stats(lootFunction = lootDefault) {
 		if (tmp.zone !== 'z6') {
 			if (tmp.value < 1 && mapLevel >= saveData.zone) continue;
 			if (tmp.canAffordPerfect) mapsCanAffordPerfect++;
-			let reachedRequiredCountOfPerfectMaps = mapsCanAffordPerfect >= requiredNumberOfPerfectMaps;
-			let runIsSufficientlyWorseThanPriorRun = tmp.value < deltaBetweenCurrentRunAndPriorRunToStopAt * (stats.length ? status[0].value : tmp.value);
-			let reachedSufficientBelowCurrentZone = mapLevel < saveData.zone - minMapsBelowCurrentZoneToRunFor;
-			let enoughSimulationCompleted = reachedRequiredCountOfPerfectMaps && runIsSufficientlyWorseThanPriorRun && reachedSufficientBelowCurrentZone;
+			const reachedRequiredCountOfPerfectMaps = mapsCanAffordPerfect >= requiredNumberOfPerfectMaps;
+			const runIsSufficientlyWorseThanPriorRun = tmp.value < deltaBetweenCurrentRunAndPriorRunToStopAt * (stats.length ? status[0].value : tmp.value);
+			const reachedSufficientBelowCurrentZone = mapLevel < saveData.zone - minMapsBelowCurrentZoneToRunFor;
+			const enoughSimulationCompleted = reachedRequiredCountOfPerfectMaps && runIsSufficientlyWorseThanPriorRun && reachedSufficientBelowCurrentZone;
 			if (enoughSimulationCompleted || stats.length >= maxMapsToCalcFor)) break;
 		}
 

--- a/mods/farmCalc.js
+++ b/mods/farmCalc.js
@@ -434,7 +434,11 @@ function stats(lootFunction = lootDefault) {
 	const onlyAllowPerfect = runningAutoTrimps && getPageSetting('onlyPerfectMaps');
 	const requiredNumberOfPerfectMaps = onlyAllowPerfect ? 6 : 1;
 	const deltaBetweenCurrentRunAndPriorRunToStopAt = 0.95;
-	const minMapsBelowCurrentZoneToRunFor = 0;
+	const isDailyRun = challengeActive('Daily');
+	const isUberIce = saveData.uberNature === 'Ice';
+	// There are a lot of complications with how ice works and how stacks with dailies work.  
+	// Do some extra simulations for them to make sure we haven't exlucded the best zone.
+	const minMapsBelowCurrentZoneToRunFor = (isDailyRun || isUberIce) ? 3 : 0;
 	const maxMapsToCalcFor = 25;
 
 	if (saveData.coordinate) {

--- a/mods/farmCalc.js
+++ b/mods/farmCalc.js
@@ -456,10 +456,10 @@ function stats(lootFunction = lootDefault) {
 			if (tmp.value < 1 && mapLevel >= saveData.zone) continue;
 			if (tmp.canAffordPerfect) mapsCanAffordPerfect++;
 			const reachedRequiredCountOfPerfectMaps = mapsCanAffordPerfect >= requiredNumberOfPerfectMaps;
-			const runIsSufficientlyWorseThanPriorRun = tmp.value < deltaBetweenCurrentRunAndPriorRunToStopAt * (stats.length ? status[0].value : tmp.value);
+			const runIsSufficientlyWorseThanPriorRun = tmp.value < deltaBetweenCurrentRunAndPriorRunToStopAt * (stats.length ? stats[0].value : tmp.value);
 			const reachedSufficientBelowCurrentZone = mapLevel < saveData.zone - minMapsBelowCurrentZoneToRunFor;
 			const enoughSimulationCompleted = reachedRequiredCountOfPerfectMaps && runIsSufficientlyWorseThanPriorRun && reachedSufficientBelowCurrentZone;
-			if (enoughSimulationCompleted || stats.length >= maxMapsToCalcFor)) break;
+			if (enoughSimulationCompleted || stats.length >= maxMapsToCalcFor) break;
 		}
 
 		stats.unshift(tmp);

--- a/mods/farmCalc.js
+++ b/mods/farmCalc.js
@@ -455,12 +455,11 @@ function stats(lootFunction = lootDefault) {
 		if (tmp.zone !== 'z6') {
 			if (tmp.value < 1 && mapLevel >= saveData.zone) continue;
 			if (tmp.canAffordPerfect) mapsCanAffordPerfect++;
-			if (stats.length && ((mapsCanAffordPerfect >= requiredNumberOfPerfectMaps 
-					&& tmp.value < deltaBetweenCurrentRunAndPriorRunToStopAt * stats[0].value 
-					&& mapLevel < saveData.zone - minMapsBelowCurrentZoneToRunFor) \
-				|| stats.length >= maxMapsToCalcFor)) {
-					break;
-				}
+			let reachedRequiredCountOfPerfectMaps = mapsCanAffordPerfect >= requiredNumberOfPerfectMaps;
+			let runIsSufficientlyWorseThanPriorRun = tmp.value < deltaBetweenCurrentRunAndPriorRunToStopAt * (stats.length ? status[0].value : tmp.value);
+			let reachedSufficientBelowCurrentZone = mapLevel < saveData.zone - minMapsBelowCurrentZoneToRunFor;
+			let enoughSimulationCompleted = reachedRequiredCountOfPerfectMaps && runIsSufficientlyWorseThanPriorRun && reachedSufficientBelowCurrentZone;
+			if (enoughSimulationCompleted || stats.length >= maxMapsToCalcFor)) break;
 		}
 
 		stats.unshift(tmp);

--- a/mods/farmCalc.js
+++ b/mods/farmCalc.js
@@ -455,7 +455,7 @@ function stats(lootFunction = lootDefault) {
 		if (tmp.zone !== 'z6') {
 			if (tmp.value < 1 && mapLevel >= saveData.zone) continue;
 			if (tmp.canAffordPerfect) mapsCanAffordPerfect++;
-						if (stats.length && ((mapsCanAffordPerfect >= requiredNumberOfPerfectMaps 
+			if (stats.length && ((mapsCanAffordPerfect >= requiredNumberOfPerfectMaps 
 					&& tmp.value < deltaBetweenCurrentRunAndPriorRunToStopAt * stats[0].value 
 					&& mapLevel < saveData.zone - minMapsBelowCurrentZoneToRunFor) \
 				|| stats.length >= maxMapsToCalcFor)) {


### PR DESCRIPTION
When I have farmCalc running in a steam install of trimps (presumed to be the same in browser), I don't get a nice printout about "the best for D stance and the best for S stance".  I just get a single value of "the best" and what stance that is in.  I shouldn't need to keep crunching numbers in this case to ultimately throw out a bunch of data.  To address this I've tried to determine if we are running as just the passive ui element and limit the number of perfect maps we need to simulate, limit how far apart the current map needs to be from the prior map to stop, and how many maps below the current zone we need to simulate to stop.

Additionally I found it weird that the simulation was going for maps which are unaffordable even at 0,0,0 and spending a bunch of time simulating them.  I added a check to prevent simulation if the map is unaffordable at all (returns value of 0 immediately).

If I can get a primer on how your styling works I can try to restyle my code so it doesn't stand out as much.  I was just trying to set it up so that I had an easier time reading it while trying to figure out what it did and working on it.