### PR TITLE
Prevent verifyLayout function from failing on empty slots

### DIFF
--- a/mods/spireTD.js
+++ b/mods/spireTD.js
@@ -1,5 +1,6 @@
 function verifyLayout(layout) {
 	for (const trap of layout) {
+		if (trap === "") continue;
 		if (playerSpireTraps[trap].locked) {
 			tooltip('confirm', null, 'update', 'Illegal trap layout. Try using <a href="http://swaqvalley.com/td_calc/" target="_blank">swaqs spire build calculator</a> instead.', 'cancelTooltip()', `Invalid Import`, 'Confirm');
 			return false;


### PR DESCRIPTION
Fixes an issue where verifyLayout failed when importing layouts with empty slots. Empty string entries are now ignored during validation.